### PR TITLE
Added quiet option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The configuration file `~/.gitpassport` is rather self-explanatory:
 [general]
 enable_hook = True
 sleep_duration = 0.5
+quiet = False
 
 [passport 0]
 email = email_0@example.com
@@ -76,6 +77,8 @@ email = email_1@example.com
 name = name_1
 service = gitlab.com
 ```
+
+Setting `quiet` to `True` will stop `git-passport.py` from printing the active passport upon default execution (To see the active passport with `quiet` enabled, you must pass the `-a` option).
 
 Adjust the existing sections and add as many passports as you like by following
 the section scheme.

--- a/git-passport.py
+++ b/git-passport.py
@@ -60,12 +60,13 @@ if __name__ == "__main__":
             exit(0)
 
         if local_email and local_name:
-            case.active_identity(
-                config,
-                local_email,
-                local_name,
-                local_url
-            )
+            if not config["quiet"]:
+                case.active_identity(
+                    config,
+                    local_email,
+                    local_name,
+                    local_url
+                )
             sys.exit(0)
 
         if local_url:

--- a/passport/configuration.py
+++ b/passport/configuration.py
@@ -32,6 +32,7 @@ def preset(filename):
     preset["general"] = {}
     preset["general"]["enable_hook"] = "True"
     preset["general"]["sleep_duration"] = "0.75"
+    preset["general"]["quiet"] = "False"
 
     preset["passport 0"] = {}
     preset["passport 0"]["email"] = "email_0@example.com"
@@ -87,7 +88,8 @@ def validate_scheme(filename):
         "enable_hook",
         "name",
         "service",
-        "sleep_duration"
+        "sleep_duration",
+        "quiet"
     ])
 
     # Create sets containing non-whitelisted section and option names
@@ -148,6 +150,7 @@ def validate_values(filename):
             email: E-Mail scheme
             sleep_duration: Float
             enable_hook: Boolean
+            quiet: Boolean
 
         Args:
             filename (str): The complete `filepath` of the configuration file
@@ -188,6 +191,14 @@ def validate_values(filename):
 
         print(msg)
         return False
+    
+    try:
+        raw_config.getboolean("general", "quiet")
+    except ValueError:
+        msg = "E > Configuration > quiet: Expecting True or False."
+
+        print(msg)
+        return False
 
     # Quit if we have wrong float values
     try:
@@ -222,6 +233,7 @@ def release(filename):
 
     config = {}
     config["enable_hook"] = raw_config.getboolean("general", "enable_hook")
+    config["quiet"] = raw_config.getboolean("general", "quiet")
     config["sleep_duration"] = raw_config.getfloat("general", "sleep_duration")
     config["git_passports"] = dict(enumerate(passport(raw_config)))
 


### PR DESCRIPTION
This adds a `quiet` option that stops passport from printing out the active passport every time you commit (which immediately became annoying to me). You can still get the active passport with the `-a` option if you need to check it though.
