### PR TITLE
made compatible for python 2.7

### DIFF
--- a/git-passport.py
+++ b/git-passport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2.7
 # -*- coding: utf-8 -*-
 
 

--- a/passport/case.py
+++ b/passport/case.py
@@ -3,7 +3,11 @@
 
 # ..................................................................... Imports
 import time
-import urllib.parse
+#import urllib.parse
+try:
+        from urllib.parse import urlparse
+except ImportError:
+        from urlparse import urlparse
 
 from . import (
     configuration,


### PR DESCRIPTION
while trying to run gitpassport it  gave an error `ImportError: No module named 'urlparse'.` upon further investigation, it was found `urlparse.urlparse` (the function) was renamed in Python 3 to `urllib.parse`. I have updated it to use python 2.7 as well 
