### PR TITLE
regex support for service parameter

### DIFF
--- a/passport/case.py
+++ b/passport/case.py
@@ -2,6 +2,7 @@
 
 
 # ..................................................................... Imports
+import re
 import time
 import urllib.parse
 
@@ -72,7 +73,7 @@ def url_exists(config, url):
     # Let's see if user defined IDs match remote.origin.url
     def gen_candidates(ids, url):
         for key, value in ids.items():
-            if value.get("service") == url:
+            if re.search(value.get("service"), url):
                 yield (key, value)
 
     local_passports = config["git_passports"]


### PR DESCRIPTION
Support regular expressions in "service = " section options.

Makes it much easier to specify multiple domains in one passport section.:

  service = domain1|domain2

Admittedly, I have not tested the use of non-letter special characters and their correct passing through ConfigParser. I just use it currently to have a default catchall:

  service = .*

This is supposed to fix issue #28 
