### PR TITLE
Add section option "no_remote = true" to allow passports for repos without a remote

### DIFF
--- a/git-passport.py
+++ b/git-passport.py
@@ -72,8 +72,12 @@ if __name__ == "__main__":
             candidates = case.url_exists(config, local_url)
         else:
             candidates = case.no_url_exists(config)
-
-        selected_id = dialog.get_input(candidates.keys())
+        
+        if args.select or len(candidates) > 1:
+            dialog.print_choice(candidates)
+            selected_id = dialog.get_input(candidates.keys())
+        else:
+            selected_id = next(iter(candidates.keys()))
         if selected_id is not None:
             git.config_set(config, candidates[selected_id]["email"], "email")
             git.config_set(config, candidates[selected_id]["name"], "name")

--- a/passport/case.py
+++ b/passport/case.py
@@ -97,7 +97,6 @@ def url_exists(config, url):
         print(util.dedented(msg, "lstrip"))
         configuration.add_global_id(config, candidates)
 
-    dialog.print_choice(candidates)
     return candidates
 
 
@@ -112,11 +111,21 @@ def no_url_exists(config):
         Returns:
             candidates (dict): Contains preselected Git ID candidates
     """
-    candidates = config["git_passports"]
-    msg = "«remote.origin.url» is not set, listing all passports:\n"
+    def gen_candidates(ids):
+        for key, value in ids.items():
+            if value.get('no_remote', False):
+                yield (key, value)
 
-    print(msg)
-    configuration.add_global_id(config, candidates)
-    dialog.print_choice(candidates)
+    local_passports = config["git_passports"]
+    candidates = dict(gen_candidates(local_passports))
+    if candidates:
+        msg = "«remote.origin.url» is not set, listing all passports with «no_remote» set:\n"
+    else:
+        msg = "«remote.origin.url» is not set, listing all passports:\n"
+        candidates = local_passports
+        configuration.add_global_id(config, candidates)
+
+    if len(candidates) > 1:
+        print(msg)
 
     return candidates

--- a/passport/dialog.py
+++ b/passport/dialog.py
@@ -59,11 +59,13 @@ def print_choice(choice):
             msg = """
                 ~:Global ID: {}
                     . User:   {}
-                    . E-Mail: {}
+                    . E-Mail: {}{}
             """.format(
                 key,
                 value["name"],
-                value["email"]
+                value["email"],
+                """
+                    . no_remote: true""" if value["no_remote"] else ''
             )
 
             print(util.dedented(msg, "lstrip"))
@@ -72,12 +74,14 @@ def print_choice(choice):
                 ~Passport ID: {}
                     . User:    {}
                     . E-Mail:  {}
-                    . Service: {}
+                    . Service: {}{}
             """.format(
                 key,
                 value["name"],
                 value["email"],
-                value["service"]
+                value["service"],
+                """
+                    . no_remote: true""" if value["no_remote"] else ''
             )
 
             print(util.dedented(msg, "lstrip"))
@@ -85,11 +89,13 @@ def print_choice(choice):
             msg = """
                 ~:Passport ID: {}
                     . User:   {}
-                    . E-Mail: {}
+                    . E-Mail: {}{}
             """.format(
                 key,
                 value["name"],
-                value["email"]
+                value["email"],
+                """
+                    . no_remote: true""" if value["no_remote"] else ''
             )
 
             print(util.dedented(msg, "lstrip"))


### PR DESCRIPTION
Projects usually do not start with a github repo, but with a

  mkdir new_project
  cd new_project
  git init

I do have a default passport setup which I would like to automatically use for these cases. Add

  no_remote = true

to any passport section that you want to use with repos that do not have a remote url.

Supports --select, and validation.
