### PR TITLE
Do not validate or parse url

### DIFF
--- a/passport/case.py
+++ b/passport/case.py
@@ -3,7 +3,6 @@
 
 # ..................................................................... Imports
 import time
-import urllib.parse
 
 from . import (
     configuration,
@@ -76,9 +75,8 @@ def url_exists(config, url):
                 yield (key, value)
 
     local_passports = config["git_passports"]
-    netloc = urllib.parse.urlparse(url)[1]
 
-    candidates = dict(gen_candidates(local_passports, netloc))
+    candidates = dict(gen_candidates(local_passports, url))
 
     if len(candidates) >= 1:
         msg = """


### PR DESCRIPTION
Pull this only after pulling `regex_service` branch.

a) After we allow regex matching in "service =" options this is no
   longer required to make usage of this option feasible
b) It was the wrong thing to do. Github and other services
   authenticate via ssh. And ~/.ssh/config allows to specify arbitrary
   names as "Host"s. So users can attach a certain ssh identity to a
   certain repo on gitlab. remote.origin.url then usually does not
   look like an url anymore and is meaningless tu urllib.parse.

Now, to passport for e.g. github, use:

```
  service = github(.com)?(:.*)?
```

This is a separate pull request to distinguish between adding the feature on the `regex_service` branch (which is somewhat backwards compatible) from this change. Not using `urllib.parse` may require users to change their configs. Since `domain.com` even as a regex still matched the origin `domain.com` in most cases this should behave fine. Anyway, explicit is better than implicit ;-)
