### PR TITLE
Handle SSH urls better and avoid race conditions when setting git local configs

### DIFF
--- a/passport/case.py
+++ b/passport/case.py
@@ -76,7 +76,16 @@ def url_exists(config, url):
                 yield (key, value)
 
     local_passports = config["git_passports"]
-    netloc = urllib.parse.urlparse(url)[1]
+
+    # For a lot of SSH git clones the scheme is implicit in the URLs provided to
+    # copy-paste from the website (ie. git@github.com:project/name.git) -
+    # without the explicit ssh:// on the front urllib doesn't play nice with
+    # the URL
+    parsedurl = urllib.parse.urlparse(url)
+    if parsedurl.hostname == None:
+        parsedurl = urllib.parse.urlparse("ssh://" + url)
+
+    netloc = parsedurl.hostname
 
     candidates = dict(gen_candidates(local_passports, netloc))
 

--- a/passport/git.py
+++ b/passport/git.py
@@ -86,13 +86,14 @@ def config_set(config, value, property):
             Exception: If subprocess.Popen() fails
     """
     try:
-        subprocess.Popen([
+        config = subprocess.Popen([
             "git",
             "config",
             "--local",
             "user." + property,
             value
         ], stdout=subprocess.PIPE)
+        config.wait()
 
     except Exception:
         raise

--- a/passport/git.py
+++ b/passport/git.py
@@ -86,20 +86,25 @@ def config_set(config, value, property):
             Exception: If subprocess.Popen() fails
     """
     try:
-        config = subprocess.Popen([
+        git_process = subprocess.Popen([
             "git",
             "config",
             "--local",
             "user." + property,
             value
         ], stdout=subprocess.PIPE)
-        config.wait()
+
+        # Captures the git return code
+        exit_status = git_process.wait()
+
+
+        if exit_status == 0:
+            return True
+        else:
+            return False
 
     except Exception:
         raise
-
-    return True
-
 
 def config_remove(verbose=True):
     """ Remove an existing Git identity.


### PR DESCRIPTION
Hi! This is a simple pull request fixing a couple issues I had locally when using this tool.

1) The SSH urls from github and elsewhere (ie. git@github.com:project/path/thing.git) weren't handled well by urllib without an explicit ssh:// scheme on the front, so to handle this I simply check if the parse failed, tack on a ssh:// and try again.

2) I got race conditions trying to set username and email without adding the git_process.wait() to the get_config method.